### PR TITLE
Replace IVGlobal.GUISize by IVGlobal.gui_size_settings for customizability

### DIFF
--- a/program/theme_manager.gd
+++ b/program/theme_manager.gd
@@ -34,8 +34,8 @@ extends RefCounted
 ## are defined and managed: "MediumFont" (dynamic), "LargeFont" (dynamic),
 ## "MediumFixedFont", and "LargeFixedFont". The main theme's default_font_size
 ## is also dynamically managed. Font sizes are determined by this class's
-## properties and (for dynamic) the global "gui_size" setting (one of
-## [enum IVGlobal.GUISize]).[br][br]
+## properties and (for dynamic) the global "gui_size" setting (a value of
+## [member IVGlobal.gui_size_settings]).[br][br]
 
 
 ## Signal provided for managing Label3D font sizing. Name and symbol sizes are

--- a/program/theme_manager.gd
+++ b/program/theme_manager.gd
@@ -35,7 +35,7 @@ extends RefCounted
 ## "MediumFixedFont", and "LargeFixedFont". The main theme's default_font_size
 ## is also dynamically managed. Font sizes are determined by this class's
 ## properties and (for dynamic) the global "gui_size" setting (a value of
-## [member IVGlobal.gui_size_settings]).[br][br]
+## [member IVCoreSettings.gui_size_settings]).[br][br]
 
 
 ## Signal provided for managing Label3D font sizing. Name and symbol sizes are

--- a/singletons/core_settings.gd
+++ b/singletons/core_settings.gd
@@ -73,7 +73,7 @@ var disable_pause := false
 var disable_exit := false
 ## See [IVStateManager].
 var disable_quit := false
-## Size multipliers corresponding to [enum IVGlobal.GUISize]. Before adjusting,
+## Size multipliers for each of [member IVGlobal.gui_size_settings]. Before adjusting,
 ## consider effects on font sizing in [IVThemeManager] (font sizes are rounded
 ## to the nearest integer after multiplication). See also [IVControlModResizable].
 var gui_size_multipliers: Array[float] = [0.75, 1.0, 1.25]
@@ -201,7 +201,7 @@ func _enter_tree() -> void:
 
 ## Called by [IVStateManager] to test valid settings.
 func assert_valid_settings() -> void:
-	assert(gui_size_multipliers.size() == IVGlobal.GUISize.size())
+	assert(gui_size_multipliers.size() == IVGlobal.gui_size_settings.size())
 	assert(stroboscope_frames_per_second >= 0.0)
 
 

--- a/singletons/core_settings.gd
+++ b/singletons/core_settings.gd
@@ -73,7 +73,13 @@ var disable_pause := false
 var disable_exit := false
 ## See [IVStateManager].
 var disable_quit := false
-## Size multipliers for each of [member IVGlobal.gui_size_settings]. Before adjusting,
+## Sizes available for setting "gui_size". See also [member gui_size_multipliers].
+var gui_size_settings: Dictionary[StringName, int] = {
+	"GUI_SMALL" = 0,
+	"GUI_MEDIUM" = 1,
+	"GUI_LARGE" = 2,
+}
+## Size multipliers for each of [member gui_size_settings]. Before adjusting,
 ## consider effects on font sizing in [IVThemeManager] (font sizes are rounded
 ## to the nearest integer after multiplication). See also [IVControlModResizable].
 var gui_size_multipliers: Array[float] = [0.75, 1.0, 1.25]
@@ -201,7 +207,7 @@ func _enter_tree() -> void:
 
 ## Called by [IVStateManager] to test valid settings.
 func assert_valid_settings() -> void:
-	assert(gui_size_multipliers.size() == IVGlobal.gui_size_settings.size())
+	assert(gui_size_multipliers.size() == gui_size_settings.size())
 	assert(stroboscope_frames_per_second >= 0.0)
 
 

--- a/singletons/global.gd
+++ b/singletons/global.gd
@@ -84,10 +84,10 @@ signal show_hide_gui_requested(is_toggle: bool, is_show: bool)
 
 
 ## Sizes available for setting "gui_size". See also [member IVCoreSettings.gui_size_multipliers].
-enum GUISize {
-	GUI_SMALL,
-	GUI_MEDIUM,
-	GUI_LARGE,
+static var gui_size_settings: Dictionary[StringName, int] = {
+	"GUI_SMALL" = 0,
+	"GUI_MEDIUM" = 1,
+	"GUI_LARGE" = 2,
 }
 
 ## Resolution choice for the background starmap; see [IVAssetPreloader].

--- a/singletons/global.gd
+++ b/singletons/global.gd
@@ -83,13 +83,6 @@ signal close_admin_popups_required()
 signal show_hide_gui_requested(is_toggle: bool, is_show: bool)
 
 
-## Sizes available for setting "gui_size". See also [member IVCoreSettings.gui_size_multipliers].
-static var gui_size_settings: Dictionary[StringName, int] = {
-	"GUI_SMALL" = 0,
-	"GUI_MEDIUM" = 1,
-	"GUI_LARGE" = 2,
-}
-
 ## Resolution choice for the background starmap; see [IVAssetPreloader].
 enum StarmapSize {
 	STARMAP_8K,

--- a/singletons/settings_manager.gd
+++ b/singletons/settings_manager.gd
@@ -67,7 +67,7 @@ var _defaults: Dictionary[StringName, Variant] = {
 
 	# UI & HUD display
 	&"language" : 0, # see IVLanguageManager
-	&"gui_size" : IVGlobal.GUISize.GUI_MEDIUM,
+	&"gui_size" : 2, # see IVGlobal
 	&"label3d_names_size_percent" : 100,
 	&"label3d_symbols_size_percent" : 100,
 	&"point_size" : 3,

--- a/ui/options_popup.gd
+++ b/ui/options_popup.gd
@@ -104,7 +104,7 @@ extends PopupPanel
 ## name.
 @export var option_enumerations: Dictionary[StringName, Array] = {
 	language = [&"LanguageManager", &"language_settings"],
-	gui_size = [&"Global", &"GUISize"],
+	gui_size = [&"Global", &"gui_size_settings"],
 	starmap = [&"Global", &"StarmapSize"],
 }
 

--- a/ui/options_popup.gd
+++ b/ui/options_popup.gd
@@ -104,7 +104,7 @@ extends PopupPanel
 ## name.
 @export var option_enumerations: Dictionary[StringName, Array] = {
 	language = [&"LanguageManager", &"language_settings"],
-	gui_size = [&"Global", &"gui_size_settings"],
+	gui_size = [&"CoreSettings", &"gui_size_settings"],
 	starmap = [&"Global", &"StarmapSize"],
 }
 

--- a/ui_components/control_mod_resizable.gd
+++ b/ui_components/control_mod_resizable.gd
@@ -51,13 +51,13 @@ extends Node
 
 
 ## Set only [member base_size] or [member sizes].
-## Base Control size multiplied by [member IVCoreSettings.gui_size_multipliers]
-## for each [enum IVGlobal.GUISize]. If set, the resulting sizes will overwrite
-## values in [member sizes]. A negative x or y means "Don't resize!" in this
-## axis (for Control not in a Container only).
+## Base Control size multiplied by [member IVCoreSettings.gui_size_multipliers] for
+## each of [member IVGlobal.gui_size_settings]. If set, the resulting sizes will
+## overwrite values in [member sizes]. A negative x or y means "Don't resize!" in
+## this axis (for Control not in a Container only).
 @export var base_size := Vector2.ZERO
 ## Set only [member base_size] or [member sizes].
-## Control size for each setting of [enum IVGlobal.GUISize]. If
+## Control size for each setting of [member IVGlobal.gui_size_settings]. If
 ## [member base_size] is set, this array will be filled (overwritten) using
 ## [member base_size] × [member IVCoreSettings.gui_size_multipliers]. A negative
 ## x or y means "Don't resize!" in this axis (for Control not in a Container only).
@@ -112,7 +112,7 @@ func _configure_after_core_inited() -> void:
 	_in_container = _control.get_parent() is Container
 	if base_size and sizes:
 		push_warning("Provided 'sizes' are overwritten using 'base_size'. Set only one of these!")
-	var n_sizes := IVGlobal.GUISize.size()
+	var n_sizes := IVGlobal.gui_size_settings.size()
 	if base_size:
 		assert(!_in_container or (base_size.x >= 0.0 and base_size.y >= 0.0),
 				"Negative size allowed only for Control not in a Container")
@@ -123,7 +123,7 @@ func _configure_after_core_inited() -> void:
 			sizes[i].x = roundf(base_size.x * multipliers[i]) if base_size.x >= 0.0 else -1.0
 			sizes[i].y = roundf(base_size.y * multipliers[i]) if base_size.y >= 0.0 else -1.0
 	elif sizes:
-		assert(sizes.size() == n_sizes, "'sizes' size does not match enum 'IVGlobal.GUISize' size")
+		assert(sizes.size() == n_sizes, "'sizes' size does not match 'IVGlobal.gui_size_settings' size")
 		if _in_container:
 			for i in n_sizes:
 				assert(sizes[i].x >= 0.0 and sizes[i].y >= 0.0,

--- a/ui_components/control_mod_resizable.gd
+++ b/ui_components/control_mod_resizable.gd
@@ -52,12 +52,12 @@ extends Node
 
 ## Set only [member base_size] or [member sizes].
 ## Base Control size multiplied by [member IVCoreSettings.gui_size_multipliers] for
-## each of [member IVGlobal.gui_size_settings]. If set, the resulting sizes will
+## each of [member IVCoreSettings.gui_size_settings]. If set, the resulting sizes will
 ## overwrite values in [member sizes]. A negative x or y means "Don't resize!" in
 ## this axis (for Control not in a Container only).
 @export var base_size := Vector2.ZERO
 ## Set only [member base_size] or [member sizes].
-## Control size for each setting of [member IVGlobal.gui_size_settings]. If
+## Control size for each setting of [member IVCoreSettings.gui_size_settings]. If
 ## [member base_size] is set, this array will be filled (overwritten) using
 ## [member base_size] × [member IVCoreSettings.gui_size_multipliers]. A negative
 ## x or y means "Don't resize!" in this axis (for Control not in a Container only).
@@ -112,7 +112,7 @@ func _configure_after_core_inited() -> void:
 	_in_container = _control.get_parent() is Container
 	if base_size and sizes:
 		push_warning("Provided 'sizes' are overwritten using 'base_size'. Set only one of these!")
-	var n_sizes := IVGlobal.gui_size_settings.size()
+	var n_sizes := IVCoreSettings.gui_size_settings.size()
 	if base_size:
 		assert(!_in_container or (base_size.x >= 0.0 and base_size.y >= 0.0),
 				"Negative size allowed only for Control not in a Container")
@@ -123,7 +123,7 @@ func _configure_after_core_inited() -> void:
 			sizes[i].x = roundf(base_size.x * multipliers[i]) if base_size.x >= 0.0 else -1.0
 			sizes[i].y = roundf(base_size.y * multipliers[i]) if base_size.y >= 0.0 else -1.0
 	elif sizes:
-		assert(sizes.size() == n_sizes, "'sizes' size does not match 'IVGlobal.gui_size_settings' size")
+		assert(sizes.size() == n_sizes, "'sizes' size does not match 'IVCoreSettings.gui_size_settings' size")
 		if _in_container:
 			for i in n_sizes:
 				assert(sizes[i].x >= 0.0 and sizes[i].y >= 0.0,


### PR DESCRIPTION
Hey there,

We require additional GUI Scales for our project and discovered that enums are not extensible in Godot. Thus, we decided to replace the enum with a dictionary. Maybe this is a change from which the core addon profits as well. Let me know what you think about this and whether you’d like me to adjust anything! :)